### PR TITLE
Cambiar título "© Inversiones" a "(F)ipanel"

### DIFF
--- a/src/components/logo/Logo.tsx
+++ b/src/components/logo/Logo.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils';
-import { CopyrightIcon } from 'lucide-react';
+import { FunctionSquareIcon } from 'lucide-react';
 
 interface LogoProps {
   long?: boolean;
@@ -8,7 +8,7 @@ interface LogoProps {
 export const Logo = ({ long }: LogoProps) => {
   return (
     <div className={cn('flex', { 'ml-1 gap-1': long })}>
-      <CopyrightIcon /> {long ? 'Inversiones' : ''}
+      <FunctionSquareIcon /> {long ? 'Fipanel' : ''}
     </div>
   );
 };


### PR DESCRIPTION
# Descripción:
Actualmente, en la esquina superior izquierda de la aplicación, el título se muestra como **© Inversiones**. Se requiere actualizar este texto a **(F)ipanel** para reflejar la nueva identidad de la plataforma.

![Image](https://github.com/user-attachments/assets/081641c6-3c11-42d8-8f52-ad509fe27121)

## Issue resolved

https://github.com/guidomodarelli/fipanel/issues/2

## Evidencia

![image](https://github.com/user-attachments/assets/82312600-a75c-40b9-9d34-1db72acbe35d)


## Criterios de aceptación:
- El título **"(F)ipanel"** debe mostrarse correctamente en la posición original.  
- La modificación debe mantenerse consistente en todo el sistema.  
- No se deben generar errores ni desalineaciones en la interfaz.
